### PR TITLE
Upgrade project to .NET 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ orbs:
 executors:
   docker-python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.11.1
   docker-terraform:
     docker:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/BaseListener.Tests/BaseListener.Tests.csproj
+++ b/BaseListener.Tests/BaseListener.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
@@ -19,9 +19,10 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
-    <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.84.0" />
+    <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.84.0" />
+    <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.84.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/BaseListener.Tests/Dockerfile
+++ b/BaseListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/BaseListener/BaseListener.csproj
+++ b/BaseListener/BaseListener.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 
@@ -18,10 +18,10 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.0.0" />
-    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.10.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
-    <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Hackney.Core.Logging" Version="1.84.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/BaseListener/Dockerfile
+++ b/BaseListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/BaseListener/Properties/launchSettings.json
+++ b/BaseListener/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
       "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-8.0.exe",
       "environmentVariables": {
         "ENVIRONMENT": "LocalDevelopment"
       }

--- a/BaseListener/Properties/launchSettings.json
+++ b/BaseListener/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\netcoreapp3.1",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
       "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe",
       "environmentVariables": {
         "ENVIRONMENT": "LocalDevelopment"

--- a/BaseListener/aws-lambda-tools-defaults.json
+++ b/BaseListener/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "default",
   "region": "eu-west-2",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
+  "framework": "net8.0",
   "function-runtime": "dotnetcore3.1",
   "function-memory-size": 256,
   "function-timeout": 30,

--- a/BaseListener/aws-lambda-tools-defaults.json
+++ b/BaseListener/aws-lambda-tools-defaults.json
@@ -9,7 +9,7 @@
   "region": "eu-west-2",
   "configuration": "Release",
   "framework": "net8.0",
-  "function-runtime": "dotnetcore3.1",
+  "function-runtime": "dotnet8",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "BaseListener::BaseListener.SqsFunction::FunctionHandler"

--- a/BaseListener/build.cmd
+++ b/BaseListener/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/base-listener.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/base-listener.zip

--- a/BaseListener/build.sh
+++ b/BaseListener/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/base-listener.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/base-listener.zip

--- a/BaseListener/serverless.yml
+++ b/BaseListener/serverless.yml
@@ -1,7 +1,7 @@
 service: base-listener
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet8
   memorySize: 2048
   tracing:
     lambda: true
@@ -12,7 +12,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/base-listener.zip
+  artifact: ./bin/release/net8.0/base-listener.zip
 
 functions:
   BaseListener:


### PR DESCRIPTION
Upgrading the base listener template to .NET 8 as .NET 3.1 is not supported by AWS.
